### PR TITLE
Add an example for Sobol sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 language: cpp
 matrix:
   include:
+    # for test coverage
     - os: linux
       compiler: gcc
       env:
@@ -18,6 +19,8 @@ matrix:
         - BUILD_TYPE=Debug
           GNS_BUILD_TEST="-DGNS_BUILD_TEST=ON"
           GNS_BUILD_TEST_MEMORYCHECK="-DGNS_BUILD_TEST_MEMORYCHECK=ON"
+          GNS_BUILD_BENCHMARKS="-DGNS_BUILD_BENCHMARKS=ON"
+          GNS_BUILD_EXAMPLES="-DGNS_BUILD_EXAMPLES=ON"
       addons:
         apt:
           sources:
@@ -35,6 +38,8 @@ matrix:
         - BUILD_TYPE=Debug
           GNS_BUILD_TEST="-DGNS_BUILD_TEST=ON"
           GNS_BUILD_TEST_MEMORYCHECK="-DGNS_BUILD_TEST_MEMORYCHECK=ON"
+          GNS_BUILD_BENCHMARKS="-DGNS_BUILD_BENCHMARKS=ON"
+          GNS_BUILD_EXAMPLES="-DGNS_BUILD_EXAMPLES=ON"
       addons:
         apt:
           sources:
@@ -51,18 +56,20 @@ matrix:
       env:
         - BUILD_TYPE=Debug
           GNS_BUILD_TEST="-DGNS_BUILD_TEST=ON"
+          GNS_BUILD_BENCHMARKS="-DGNS_BUILD_BENCHMARKS=ON"
+          GNS_BUILD_EXAMPLES="-DGNS_BUILD_EXAMPLES=ON"
     - os: osx
       compiler: clang++
       # addons:
       env:
         - BUILD_TYPE=Debug
           GNS_BUILD_TEST="-DGNS_BUILD_TEST=ON"
+          GNS_BUILD_BENCHMARKS="-DGNS_BUILD_BENCHMARKS=ON"
+          GNS_BUILD_EXAMPLES="-DGNS_BUILD_EXAMPLES=ON"
 before_install:
   - echo $LANG
   - echo $LC_ALL
   - ls -la
-  - export GNS_BUILD_BENCHMARKS="-DGNS_BUILD_BENCHMARKS=ON"
-  - export GNS_BUILD_EXAMPLES="-DGNS_BUILD_EXAMPLES=OFF"
   - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CXX" == "g++" ]; then brew install gcc48; fi
   # valgrind does not work in osx so we only test with valgrind on linux
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ IF(GNS_BUILD_BENCHMARKS)
     ADD_SUBDIRECTORY(benchmarks)
 ENDIF()
 
-# benchmarks
+# examples
 IF(GNS_BUILD_EXAMPLES)
     ADD_SUBDIRECTORY(examples)
 ENDIF()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,28 @@
+LIST (APPEND examples_PROGRAMS
+    example_sequence_sobol.cc
+)
+INCLUDE_DIRECTORIES(
+    ${PROJECT_SOURCE_DIR}
+)
+
+# WithoutExtension
+FOREACH (source_file ${examples_PROGRAMS})
+    GET_FILENAME_COMPONENT (source_file_we ${source_file} NAME_WE)
+    ADD_EXECUTABLE (
+        ${source_file_we}
+        ${source_file}
+    )
+    TARGET_LINK_LIBRARIES (${source_file_we}
+        gns
+    )
+    ADD_TEST (${source_file_we} ${source_file_we})
+    IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        SET (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+        SET (CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
+        SET (CMAKE_CXX_FLAGS "-g -O3 ${CMAKE_CXX_FLAGS}")
+        SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS "${CMAKE_CXX_FLAGS}")
+    ENDIF ()
+    IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        SET_PROPERTY (TARGET ${source_file_we} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-mismatched-tags")
+    ENDIF ()
+ENDFOREACH ()

--- a/examples/example_sequence_sobol.cc
+++ b/examples/example_sequence_sobol.cc
@@ -1,0 +1,88 @@
+#include "gns/sequence_sobol.h"
+#include <cmath>
+#include <iomanip>
+#include <random>
+
+double EstimatePiQMC(const size_t num_point)
+{
+  gns::Sobol<2> sobol(2);
+  size_t num_inner_point = 0;
+  for (size_t i = 0; i < num_point; ++i) {
+      std::unique_ptr<double[]> point = sobol.Next();
+      const double r = point[0] * point[0] + point[1] * point[1];
+      if (r <= 1.0) {
+        ++num_inner_point;
+      }
+  }
+  return 4.0 * (num_inner_point / static_cast<double>(num_point));
+}
+
+double EstimatePiMC(const size_t num_point)
+{
+  std::mt19937 engine(0); 
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  dist(engine);
+  size_t num_inner_point = 0;
+  for (size_t i = 0; i < num_point; ++i) {
+      const double p0 = dist(engine);
+      const double p1 = dist(engine);
+      const double r = p0 * p0 + p1 * p1;
+      if (r <= 1.0) {
+        ++num_inner_point;
+      }
+  }
+  return 4.0 * (num_inner_point / static_cast<double>(num_point));
+}
+
+void Display(
+    const std::vector<size_t>& data,
+    const std::vector<double>& qmc,
+    const std::vector<double>& mc,
+    const double true_value)
+{
+  std::cout
+    << std::setw(15)
+    << "data"
+    << std::setw(15)
+    << "QMC"
+    << std::setw(15)
+    << "MC"
+    << std::setw(15)
+    << "diff QMC"
+    << std::setw(15)
+    << "diff MC"
+    << std::endl;
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    std::cout
+      << std::fixed
+      << std::setprecision(8)
+      << std::setw(15)
+      << data[i]
+      << std::setw(15)
+      << qmc[i]
+      << std::setw(15)
+      << mc[i]
+      << std::setw(15)
+      << std::abs(qmc[i] - true_value)
+      << std::setw(15)
+      << std::abs(mc[i] - true_value)
+      << std::endl;
+  }
+}
+
+
+int main(int argc, char const* argv[])
+{
+  constexpr double PI = 3.14159265358979323846;
+  std::vector<size_t> data = {
+    100, 1000, 10000, 100000
+  };
+  std::vector<double> pi_qmc(data.size());
+  std::transform(data.begin(), data.end(), pi_qmc.begin(), EstimatePiQMC);
+  std::vector<double> pi_mc(data.size());
+  std::transform(data.begin(), data.end(), pi_mc.begin(), EstimatePiMC);
+
+  Display(data, pi_qmc, pi_mc, PI);
+  return 0;
+}


### PR DESCRIPTION
This PR adds an example of Sobol sequence by estimating circular constant.
The example compares estimated pi by quasi monte calro with estimated one by monte carlo.
The example shows the difference of convergence rate between monte carlo and quasi monte carlo.

\## Todo
We need to compare with speed of generating points between MC and QMC so that benchmark for that should be implemented.
See #6.