### PR TITLE
Add a benchmark to compare MC with QMC

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 LIST (APPEND benchmarks_PROGRAMS
-    galois_field_operator.cc
-    sequence_sobol.cc
+    benchmark_galois_field_operator.cc
+    benchmark_sequence_sobol.cc
 )
 INCLUDE_DIRECTORIES(
     ${PROJECT_SOURCE_DIR}

--- a/benchmarks/benchmark_galois_field_operator.cc
+++ b/benchmarks/benchmark_galois_field_operator.cc
@@ -1,5 +1,6 @@
 #include <benchmark/benchmark.h>
-#include "benchmarks/galois_field_operator.h"
+#include "gns/galois_field.h"
+#include "gns/galois_field_operator.h"
 
 
 #define BenchmarkGaloisFieldOperator(op, op_name)                        \

--- a/benchmarks/benchmark_sequence_sobol.cc
+++ b/benchmarks/benchmark_sequence_sobol.cc
@@ -1,4 +1,4 @@
-#include "benchmarks/sequence_sobol.h"
+#include "gns/sequence_sobol.h"
 #include <benchmark/benchmark.h>
 #include <cmath>
 #include <iomanip>

--- a/benchmarks/galois_field_operator.h
+++ b/benchmarks/galois_field_operator.h
@@ -1,3 +1,0 @@
-#pragma once
-#include "gns/galois_field.h"
-#include "gns/galois_field_operator.h"

--- a/benchmarks/sequence_sobol.cc
+++ b/benchmarks/sequence_sobol.cc
@@ -1,22 +1,60 @@
 #include "benchmarks/sequence_sobol.h"
 #include <benchmark/benchmark.h>
+#include <cmath>
+#include <iomanip>
+#include <random>
+
+static double EstimatePiSobol(const size_t num_point)
+{
+  gns::Sobol<2> sobol(2);
+  size_t num_inner_point = 0;
+  for (size_t i = 0; i < num_point; ++i) {
+      std::unique_ptr<double[]> point = sobol.Next();
+      const double r = point[0] * point[0] + point[1] * point[1];
+      if (r <= 1.0) {
+        ++num_inner_point;
+      }
+  }
+  return 4.0 * (num_inner_point / static_cast<double>(num_point));
+}
 
 static void BenchmarkSobol(benchmark::State& state)
 {
   while(state.KeepRunning()) {
-    gns::Sobol<2> sobol(2);
-    size_t num_inner_point = 0;
-    const size_t num_point = 1000;
-    for (size_t i = 0; i < num_point; ++i) {
-        std::unique_ptr<double[]> point = sobol.Next();
-        const double r = point[0] * point[0] + point[1] * point[1];
-        if (r <= 1.0) {
-          ++num_inner_point;
-        }
-    }
-    benchmark::DoNotOptimize(4.0 * (num_inner_point / static_cast<double>(num_point)));
+    benchmark::DoNotOptimize(EstimatePiSobol(state.range(0)));
   }
 }
-BENCHMARK(BenchmarkSobol);
+BENCHMARK(BenchmarkSobol)
+  ->Arg(100)
+  ->Arg(1000)
+  ->Arg(10000);
+
+static double EstimatePiMC(const size_t num_point)
+{
+  std::mt19937 engine(0); 
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  dist(engine);
+  size_t num_inner_point = 0;
+  for (size_t i = 0; i < num_point; ++i) {
+      const double p0 = dist(engine);
+      const double p1 = dist(engine);
+      const double r = p0 * p0 + p1 * p1;
+      if (r <= 1.0) {
+        ++num_inner_point;
+      }
+  }
+  return 4.0 * (num_inner_point / static_cast<double>(num_point));
+}
+
+static void BenchmarkMonteCarlo(benchmark::State& state)
+{
+  while(state.KeepRunning()) {
+    benchmark::DoNotOptimize(EstimatePiMC(state.range(0)));
+  }
+}
+BENCHMARK(BenchmarkMonteCarlo)
+  ->Arg(100)
+  ->Arg(1000)
+  ->Arg(10000);
 
 BENCHMARK_MAIN();

--- a/benchmarks/sequence_sobol.h
+++ b/benchmarks/sequence_sobol.h
@@ -1,2 +1,0 @@
-#pragma once
-#include "gns/sequence_sobol.h"


### PR DESCRIPTION
To compare speed of the speed between MC and QMC, we need to add a benchmark.
Theoretically convergence rate of QMC is better than MC so QMC is often a good choice to numerical integral.
But generally the generation speed of QMC is slower than MC although it deeply depends on the way to implement it.
So we should carefully watch perforamnce of QMC through the benchmark.