### PR TITLE
Add sobol generator with gray map

### DIFF
--- a/benchmarks/benchmark_sequence_sobol.cc
+++ b/benchmarks/benchmark_sequence_sobol.cc
@@ -29,6 +29,31 @@ BENCHMARK(BenchmarkSobol)
   ->Arg(1000)
   ->Arg(10000);
 
+static double EstimatePiSobolGrayMap(const size_t num_point)
+{
+  gns::SobolGrayMap<2> sobol(2);
+  size_t num_inner_point = 0;
+  for (size_t i = 0; i < num_point; ++i) {
+      const std::unique_ptr<double[]>& point = sobol.Next();
+      const double r = point[0] * point[0] + point[1] * point[1];
+      if (r <= 1.0) {
+        ++num_inner_point;
+      }
+  }
+  return 4.0 * (num_inner_point / static_cast<double>(num_point));
+}
+
+static void BenchmarkSobolGrayMap(benchmark::State& state)
+{
+  while(state.KeepRunning()) {
+    benchmark::DoNotOptimize(EstimatePiSobolGrayMap(state.range(0)));
+  }
+}
+BENCHMARK(BenchmarkSobolGrayMap)
+  ->Arg(100)
+  ->Arg(1000)
+  ->Arg(10000);
+
 static double EstimatePiMC(const size_t num_point)
 {
   std::mt19937 engine(0); 

--- a/gns/sequence_sobol_test.cc
+++ b/gns/sequence_sobol_test.cc
@@ -74,6 +74,7 @@ TEST(sequence_sobol, NextTest) {
   // dim =2
   {
     std::vector<std::vector<double>> expect({
+    // clang-format off
         {0.0, 0.0},
         {0.5, 0.5},
         {0.25, 0.75},
@@ -84,10 +85,53 @@ TEST(sequence_sobol, NextTest) {
         {0.875, 0.875},
         {0.0625, 0.9375},
         {0.5625, 0.4375},
+    // clang-format on
     });
     Sobol<2> sobol(2);
     for (size_t i = 0; i < expect.size(); ++i) {
       std::unique_ptr<double[]> point = sobol.Next();
+      EXPECT_DOUBLE_EQ(expect[i][0], point[0]);
+      EXPECT_DOUBLE_EQ(expect[i][1], point[1]);
+    }
+  }
+}
+
+
+TEST(sequence_sobol_test, SobolGrayMapNext) {
+  // dim=1
+  {
+    std::vector<double> expect({0.0, 0.5, 0.75, 0.25});
+    SobolGrayMap<2> sobol(1);
+    for (size_t i = 0; i < expect.size(); ++i) {
+      const std::unique_ptr<double[]>& point = sobol.Next();
+      EXPECT_DOUBLE_EQ(expect[i], point[0]);
+    }
+  }
+  // dim =2
+  {
+    std::vector<std::vector<double>> expect({
+    // clang-format off
+      { 0.0, 0.0 },
+      { 0.5, 0.5 },
+      { 0.75, 0.25 },
+      { 0.25, 0.75 },
+      { 0.375, 0.375 },
+      { 0.875, 0.875 },
+      { 0.625, 0.125 },
+      { 0.125, 0.625 },
+      { 0.1875, 0.3125 },
+      { 0.6875, 0.8125 },
+      { 0.9375, 0.0625 },
+      { 0.4375, 0.5625 },
+      { 0.3125, 0.1875 },
+      { 0.8125, 0.6875 },
+      { 0.5625, 0.4375 },
+      { 0.0625, 0.9375 },
+    // clang-format on
+    });
+    SobolGrayMap<2> sobol(2);
+    for (size_t i = 0; i < expect.size(); ++i) {
+      const std::unique_ptr<double[]>& point = sobol.Next();
       EXPECT_DOUBLE_EQ(expect[i][0], point[0]);
       EXPECT_DOUBLE_EQ(expect[i][1], point[1]);
     }

--- a/gns/vector.h
+++ b/gns/vector.h
@@ -12,6 +12,8 @@ class Vector {
   // public typedef
  public:
   typedef GaloisField<Base> value_type;
+  typedef GaloisField<Base>* iterator;
+  typedef const GaloisField<Base>* const_iterator;
   // public function
  public:
   /**
@@ -102,6 +104,22 @@ class Vector {
   }
 
   inline size_t Size() const { return size_; }
+
+  inline iterator begin() {
+    return data_.get();
+  }
+
+  inline const_iterator begin() const {
+    return data_.get();
+  }
+
+  inline iterator end() {
+    return data_.get() + size_;
+  }
+
+  inline const_iterator end() const {
+    return data_.get() + size_;
+  }
 
   // private function
  private:


### PR DESCRIPTION
Benchamrks show that time to generate sobol is much slower than time tot genreate pseudo random points.
Gray map technique is commonly used to reduce time of generation.
This PR just introduce sobol with gray map.