### PR TITLE
Fix build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,15 @@ before_install:
   - echo $LANG
   - echo $LC_ALL
   - ls -la
-  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CXX" == "g++" ]; then brew install gcc48; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CXX" == "g++" ]; then
+      gcc --version;
+      g++ --version;
+      brew update;
+      brew install gcc@5 || brew link --overwrite gcc@5;
+      gcc --version;
+      g++ --version;
+      export CXX="g++";
+    fi
   # valgrind does not work in osx so we only test with valgrind on linux
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       export BASEPATH=`pwd`;
@@ -107,8 +115,8 @@ before_install:
     fi
 install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ci/travis_cmake_setup.sh; fi
-  # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available. This is for both OSes.
-  - if [ "$CXX" == "g++" ]; then
+  # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available
+  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" == "g++" ]; then
       export CXX="g++-4.8" CC="gcc-4.8";
     fi
   - if [ "${BUILD_TYPE}" == "Coverage" -a "${TRAVIS_OS_NAME}" == "linux" ]; then

--- a/gns/test_util/gtest_assertion.h
+++ b/gns/test_util/gtest_assertion.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <gtest/gtest.h>
 #include "gns/fwd.h"
+#include <functional>
 
 #define GNS_EXPECT_VECTOR_ELEMENT_EQ(expect, actual) \
   EXPECT_TRUE(gns::IsElementEqual(expect, actual));


### PR DESCRIPTION
## Summary
Fix build failure.  The formula for gcc 4.8 is not available anymore so that we update it to gcc 5.
See [Search and discover Homebrew formulae — BrewFormulas](http://brewformulas.org/search?utf8=%E2%9C%93&search%5Bterms%5D=gcc&button=&search%5Bnames%5D=0&search%5Bnames%5D=1&search%5Bfilenames%5D=0&search%5Bfilenames%5D=1&search%5Bdescriptions%5D=0&search%5Bdescriptions%5D=1).